### PR TITLE
use batching for snapshots, too (#140)

### DIFF
--- a/nakadi-producer-loadtest/pom.xml
+++ b/nakadi-producer-loadtest/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>42.3.8</version>
         </dependency>
         <dependency>
             <groupId>org.zalando.stups</groupId>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.25</version>
+            <version>42.4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nakadi-producer-spring-boot-starter/pom.xml
+++ b/nakadi-producer-spring-boot-starter/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.4.1</version>
+            <version>42.4.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is an add-on to https://github.com/zalando-nakadi/nakadi-producer-spring-boot-starter/pull/141 to also use the batch-event-storage when creating snapshot events.

We can integrate it into this PR, or make it a separate PR to the master branch.